### PR TITLE
Configure pymysql in pytest action

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,12 +30,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt pytest-cov
 
+      - name: Set environment variables and reinstall pymssql
+        run: |
+          export LDFLAGS="-L/opt/homebrew/lib -L/opt/homebrew/opt/openssl/lib"
+          export CFLAGS="-I/opt/homebrew/include"
+          export CPPFLAGS="-I/opt/homebrew/opt/openssl@3/include"
+          pip install pymssql==2.2.8 --no-binary :all:
+
       - name: Run Pytest with Coverage Check
         run: |
           if python -m pytest --collect-only | grep -q "collected 0 items"; then
-          echo "No tests collected, skipping coverage check."
+            echo "No tests collected, skipping coverage check."
           else
-          python -m pytest --cov=./ --cov-config=.coveragerc --cov-fail-under=80
+            python -m pytest --cov=./ --cov-config=.coveragerc --cov-fail-under=80
           fi
 
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y freetds-bin freetds-dev
+          sudo apt-get install -y freetds-bin freetds-dev libkrb5-dev
+
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,7 +25,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Install dependencies
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y freetds-bin freetds-dev
+
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt pytest-cov
@@ -35,6 +40,7 @@ jobs:
           export LDFLAGS="-L/opt/homebrew/lib -L/opt/homebrew/opt/openssl/lib"
           export CFLAGS="-I/opt/homebrew/include"
           export CPPFLAGS="-I/opt/homebrew/opt/openssl@3/include"
+          pip uninstall pymssql -y
           pip install pymssql==2.2.8 --no-binary :all:
 
       - name: Run Pytest with Coverage Check
@@ -44,6 +50,8 @@ jobs:
           else
             python -m pytest --cov=./ --cov-config=.coveragerc --cov-fail-under=80
           fi
+
+
 
 
 


### PR DESCRIPTION
This should now run the necessary configuration commands to allow the use of pymysql for SQL server. Admittedly, this will slow down this action...

Closes #131 