### PR TITLE
Finally got tests working for new upload_new_plants function

### DIFF
--- a/pipeline/upload/test_upload.py
+++ b/pipeline/upload/test_upload.py
@@ -1,0 +1,124 @@
+"""Test functions from upload.py module"""
+
+import pandas as pd
+from unittest.mock import MagicMock, patch
+
+from upload import (
+    get_existing_plant_ids,
+    upload_new_plants_with_location,
+)
+
+def test_get_existing_plant_ids_empty():
+    """
+    Test that if no plant_ids are passed, an empty set is returned
+    and no query is executed.
+    """
+    mock_cursor = MagicMock()
+    result = get_existing_plant_ids(mock_cursor, [])
+    assert result == set()
+    mock_cursor.execute.assert_not_called()
+
+def test_get_existing_plant_ids_returns_set():
+    """
+    Test that get_existing_plant_ids returns the correct set given some fake database rows.
+    """
+    mock_cursor = MagicMock()
+    # Suppose the database returns plant_ids 1 and 3 for the query.
+    plant_ids = [1, 2, 3]
+    mock_cursor.fetchall.return_value = [(1,), (3,)]
+    result = get_existing_plant_ids(mock_cursor, plant_ids)
+    placeholders = ", ".join(["%s"] * len(plant_ids))
+    expected_query = f"SELECT plant_id FROM alpha.plant WHERE plant_id IN ({placeholders})"
+    mock_cursor.execute.assert_called_once_with(expected_query, tuple(plant_ids))
+    
+    assert result == {1, 3}
+
+
+@patch("upload.get_connection")
+def test_upload_new_plants_with_location_no_new(mock_get_connection):
+    """
+    Test that if all plants in the DataFrame already exist, 
+    the function prints a message and closes the connection without executing MERGE queries.
+    """
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.cursor.return_value = mock_cursor
+    
+    test_plant_id = 9999
+    data = pd.DataFrame([{
+        "botanist_email": "test@example.com",
+        "botanist_name": "Test Botanist",
+        "botanist_phone": "123456789",
+        "region": "Test Region",
+        "country": "TR",
+        "scientific_name": "Testus plantus",
+        "image_license": 1,
+        "license_name": "Test License",
+        "image_original_url": "http://example.com/image.jpg",
+        "last_watered": pd.to_datetime("2025-01-01 00:00:00"),
+        "recording_taken": pd.to_datetime("2025-01-01 00:00:00"),
+        "plant_id": test_plant_id,
+        "soil_moisture": 50.0,
+        "temperature": 20.0,
+        "name": "Test Plant",
+        "latitude": 10.0,
+        "longitude": 20.0,
+        "image_id": None
+    }])
+    
+    mock_cursor.fetchall.return_value = [(test_plant_id,)]
+    
+    upload_new_plants_with_location(data)
+    
+    mock_conn.close.assert_called_once()
+    # Because no new plant is uploaded, none of the MERGE queries should be executed.
+    # (The first call to execute is in get_existing_plant_ids, but after that, nothing else should be executed.)
+    assert mock_cursor.execute.call_count == 1
+
+
+@patch("upload.get_connection")
+def test_upload_new_plants_with_location_new(mock_get_connection):
+    """
+    Test that if a new plant is provided, the function executes the MERGE queries
+    and commits/closes the connection.
+    """
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.cursor.return_value = mock_cursor
+
+    test_plant_id = 8888
+    data = pd.DataFrame([{
+        "botanist_email": "new@example.com",
+        "botanist_name": "New Botanist",
+        "botanist_phone": "987654321",
+        "region": "New Region",
+        "country": "NR",
+        "scientific_name": "Newus plantus",
+        "image_license": 1,
+        "license_name": "New License",
+        "image_original_url": "http://example.com/new_image.jpg",
+        "last_watered": pd.to_datetime("2025-02-01 00:00:00"),
+        "recording_taken": pd.to_datetime("2025-02-01 00:00:00"),
+        "plant_id": test_plant_id,
+        "soil_moisture": 60.0,
+        "temperature": 22.0,
+        "name": "New Plant",
+        "latitude": 30.0,
+        "longitude": 40.0,
+        "image_id": None
+    }])
+    
+    # Simulate that there are no existing plant_ids by returning an empty list.
+    mock_cursor.fetchall.return_value = []
+    
+    upload_new_plants_with_location(data)
+    
+    # There are four MERGE statements in the loop for each plant.
+    # In this case, we expect 4 execute calls inside the loop plus 1 call from get_existing_plant_ids.
+    assert mock_cursor.execute.call_count == 5
+    
+    # Ensure that commit and close are called.
+    mock_conn.commit.assert_called_once()
+    mock_conn.close.assert_called_once()

--- a/pipeline/upload/upload.py
+++ b/pipeline/upload/upload.py
@@ -1,0 +1,144 @@
+import pymssql
+import pandas as pd
+from dotenv import load_dotenv
+import os
+from pymssql import Connection
+
+def get_connection() -> Connection:
+    """
+    Returns a connection object to connect to the database,
+    using all the required environment variables.
+    """
+    conn = pymssql.connect(
+        server=os.environ["DB_HOST"],
+        port=int(os.environ["DB_PORT"]),
+        user=os.environ["DB_USER"],
+        password=os.environ["DB_PASSWORD"],
+        database=os.environ["DB_NAME"]
+    )
+    return conn
+
+def get_existing_plant_ids(cursor, plant_ids: list) -> set:
+    """
+    Returns a set of plant_ids that already exist in the database.
+    """
+    if not plant_ids:
+        return set()
+    
+    placeholders = ", ".join(["%s"] * len(plant_ids))
+    query = f"SELECT plant_id FROM alpha.plant WHERE plant_id IN ({placeholders})"
+    cursor.execute(query, tuple(plant_ids))
+    rows = cursor.fetchall()
+    return {row[0] for row in rows}
+
+def upload_new_plants_with_location(data: pd.DataFrame) -> None:
+    """
+    Uploads all new plants along with their country, region, location, and plant details
+    using SQL Server's MERGE statement.
+    """
+    conn = get_connection()
+    cursor = conn.cursor()
+
+    plant_ids_in_data = data["plant_id"].tolist()
+
+    existing_ids = get_existing_plant_ids(cursor, plant_ids_in_data)
+    print(f"Existing plant IDs in DB: {existing_ids}")
+
+    new_plants_data = data[~data["plant_id"].isin(existing_ids)]
+    if new_plants_data.empty:
+        print("No new plants to upload.")
+        conn.close()
+        return
+    else:
+        print(f"New plant IDs to upload: {new_plants_data['plant_id'].tolist()}")
+
+    for _, plant in new_plants_data.iterrows():
+        cursor.execute(
+            """
+            MERGE alpha.country AS target
+            USING (SELECT %s AS country_code) AS source
+            ON target.country_code = source.country_code
+            WHEN NOT MATCHED THEN
+                INSERT (country_code)
+                VALUES (source.country_code);
+            """,
+            (plant["country"],)
+        )
+
+        cursor.execute(
+            """
+            MERGE alpha.region AS target
+            USING (SELECT %s AS region_name, (
+                    SELECT country_id FROM alpha.country WHERE country_code = %s
+                ) AS country_id) AS source
+            ON target.region_name = source.region_name AND target.country_id = source.country_id
+            WHEN NOT MATCHED THEN
+                INSERT (region_name, country_id)
+                VALUES (source.region_name, source.country_id);
+            """,
+            (plant["region"], plant["country"])
+        )
+
+        cursor.execute(
+            """
+            MERGE alpha.location AS target
+            USING (SELECT %s AS latitude, %s AS longitude, (
+                    SELECT region_id FROM alpha.region WHERE region_name = %s
+                ) AS region_id) AS source
+            ON target.latitude = source.latitude AND target.longitude = source.longitude AND target.region_id = source.region_id
+            WHEN NOT MATCHED THEN
+                INSERT (latitude, longitude, region_id)
+                VALUES (source.latitude, source.longitude, source.region_id);
+            """,
+            (plant["latitude"], plant["longitude"], plant["region"])
+        )
+
+        cursor.execute(
+            """
+            MERGE alpha.plant AS target
+            USING (SELECT %s AS plant_id, (
+                    SELECT location_id FROM alpha.location WHERE latitude = %s AND longitude = %s
+                ) AS location_id, %s AS scientific_name, %s AS image_id, %s AS common_name) AS source
+            ON target.plant_id = source.plant_id
+            WHEN NOT MATCHED THEN
+                INSERT (plant_id, location_id, scientific_name, image_id, common_name)
+                VALUES (source.plant_id, source.location_id, source.scientific_name, source.image_id, source.common_name);
+            """,
+            (
+                plant["plant_id"],
+                plant["latitude"], plant["longitude"],
+                plant["scientific_name"],
+                plant["image_id"],
+                plant["name"]
+            )
+        )
+    conn.commit()
+    conn.close()
+    print("Upload process completed.")
+
+if __name__ == '__main__':
+    load_dotenv()
+
+    new_plant_data = pd.DataFrame([{
+        "botanist_email": "eliza.andrews@lnhm.co.uk",
+        "botanist_name": "Eliza Andrews",
+        "botanist_phone": "(846)669-6651x75948",
+        "region": "Mars Outpost Alpha",
+        "country": "MC",
+        "scientific_name": "Extra Terrestrialus",
+        "image_license": 451,
+        "license_name": "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+        "image_original_url": "https://perenual.com/storage/image/alien_flower.jpg",
+        "last_watered": pd.to_datetime("2025-02-05 13:23:01"),
+        "recording_taken": pd.to_datetime("2025-02-06 11:45:30"),
+        "plant_id": 9999,
+        "soil_moisture": 99.99,
+        "temperature": -42.42,
+        "name": "Martian Death Bloom",
+        "latitude": 0.0,      
+        "longitude": 0.0,     
+        "image_id": None      
+    }])
+
+    print(new_plant_data)
+    upload_new_plants_with_location(new_plant_data)


### PR DESCRIPTION
The function will scan a batch of plant data, gathering all unique ids. If any of these ids are not currently in the plant table, the plant data will be added to the relevant tables (using merge to attempt insertion to other tables such as country etc., if said location does not exist in the table already)